### PR TITLE
Link to events info page onSelectEvent

### DIFF
--- a/src/assets/eventsList.css
+++ b/src/assets/eventsList.css
@@ -5,3 +5,7 @@
 .rbc-toolbar-label {
   font-size: 24px !important;
 }
+
+.rbc-event-label {
+  display: none !important;
+}

--- a/src/containers/EventsList.js
+++ b/src/containers/EventsList.js
@@ -15,6 +15,10 @@ export class EventsList extends Component {
     }
   }
 
+  handleSelectEvent = event => {
+    this.props.history.push(`/events/${event.slug}`)
+  }
+
   render () {
     let { events } = this.props
     const localizer = BigCalendar.momentLocalizer(moment)
@@ -27,8 +31,7 @@ export class EventsList extends Component {
             events={events}
             views={['week', 'month', 'day']}
             defaultView={BigCalendar.Views.WEEK}
-            startAccessor='start'
-            endAccessor='end'
+            onSelectEvent={this.handleSelectEvent}
           />
         </Container>
       </Fragment>

--- a/src/fixtures/events.js
+++ b/src/fixtures/events.js
@@ -1,7 +1,8 @@
 export default [
   {
-    end: '2018-11-28T12:17:00',
-    start: '2018-11-28T12:02:00',
-    title: '"Martin Fowler" Scrum'
+    end: new Date(),
+    start: new Date(),
+    title: '"Martin Fowler" Scrum',
+    slug: 'martin-fowler-scrum-and-pair-hookup'
   }
 ]

--- a/src/tests/containers/EventsList.test.js
+++ b/src/tests/containers/EventsList.test.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { EventsList } from '../../containers/EventsList'
+import events from '../../fixtures/events'
 
 describe('Events List', () => {
   let wrapper
   const props = {
     events: [],
-    fetchEvents: jest.fn()
+    fetchEvents: jest.fn(),
+    history: { push: jest.fn() }
   }
   beforeEach(() => {
     wrapper = mount(<EventsList {...props} />)
@@ -18,5 +20,14 @@ describe('Events List', () => {
 
   it('displays a calendar for events', () => {
     expect(wrapper.find('Calendar')).toHaveLength(1)
+  })
+
+  it('redirects to event info page when an event is selected in the calendar', () => {
+    wrapper = mount(<EventsList {...props} events={events} />)
+    let eventToSelect = wrapper.find('div').filterWhere(item => {
+      return item.hasClass('rbc-event-content')
+    })
+    eventToSelect.simulate('click')
+    expect(props.history.push).toHaveBeenCalledWith(`/events/${events[0].slug}`)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When a user clicks on an event in the calendar it redirects them to its info page
#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne-FE/issues  -->

fixes #119 

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne-FE/blob/develop/CONTRIBUTING.md#git-and-github-->
tested onSelectEvent by clicking on an event in the calendar and making sure `this.props.history.push` is called