### PR TITLE
Remove navbar tests that count the number of links

### DIFF
--- a/src/tests/components/Navbar.test.js
+++ b/src/tests/components/Navbar.test.js
@@ -13,16 +13,6 @@ describe('Navbar', () => {
       expect(wrapper.find('Navbar').length).toEqual(1)
     })
 
-    it('renders 7 MenuItem elements', () => {
-      const wrapper = homepage(props)
-      expect(wrapper.find('MenuItem').length).toEqual(7)
-    })
-
-    it('renders 7 Link elements', () => {
-      const wrapper = homepage(props)
-      expect(wrapper.find('Link').length).toEqual(7)
-    })
-
     it('renders 1 active Link element', () => {
       const wrapper = homepage(props)
       expect(wrapper.find('.active').find('Link').length).toEqual(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove tests that count number of links in the navbar
#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne-FE/issues  -->

fixes #128 

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne-FE/blob/develop/CONTRIBUTING.md#git-and-github-->
