### PR TITLE
Add ability to log out

### DIFF
--- a/src/components/homepage/Homepage.js
+++ b/src/components/homepage/Homepage.js
@@ -11,7 +11,7 @@ export class Homepage extends Component {
         <HomepageModal key={id} modal={modal} />
       )
     })
-  };
+  }
 
   render () {
     return (

--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -1,10 +1,9 @@
 import React, { Component, Fragment } from 'react'
-import { Menu, Container, Image } from 'semantic-ui-react'
+import { Menu, Container, Image, Icon } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import { withRouter } from 'react-router'
 import logo from '../../images/av-logo.svg'
 import './Navbar.css'
-
 export class Navbar extends Component {
   currentPath () {
     // this.props.location.split("/") returns ["", ""] when on homepage
@@ -14,9 +13,13 @@ export class Navbar extends Component {
     return pathArray[1]
   }
 
+  handleRemoveCookies = () => {
+    this.props.cookies.remove('_WebsiteOne_session')
+  }
+
   render () {
-    const activeItem = this.currentPath()
     const { cookies } = this.props
+    const activeItem = this.currentPath()
     return (
       <Menu stackable borderless inverted as='div' className='navbar'>
         <Container>
@@ -81,7 +84,15 @@ export class Navbar extends Component {
                   <Link to='/signup'>Sign up</Link>
                 </Menu.Item>
               </Fragment>
-              : null}
+              : <Menu.Item
+                name='signout'
+                active={activeItem === 'signout'}
+              >
+                <Link to='/' onClick={this.handleRemoveCookies}>
+                  <Icon name='sign-out' />
+                  Log out
+                </Link>
+              </Menu.Item>}
           </Menu.Menu>
         </Container>
       </Menu>

--- a/src/tests/components/Navbar.test.js
+++ b/src/tests/components/Navbar.test.js
@@ -7,7 +7,7 @@ describe('Navbar', () => {
   let wrapper
   const props = {
     location: { pathname: '/users' },
-    cookies: { get: jest.fn() }
+    cookies: { get: jest.fn(), remove: jest.fn() }
   }
 
   beforeEach(() => {
@@ -53,18 +53,18 @@ describe('Navbar', () => {
       expect(loginLink.text()).toEqual('Sign up')
     })
 
-    it('renders 9 menu items if a user is not signed in', () => {
-      expect(wrapper.find('MenuItem').length).toEqual(9)
-    })
-
-    it('renders 7 menu items if a user is signed in', () => {
+    it('renders a log out link when a user is signed in, which calls handleRemoveCookies function when clicked', () => {
       props.cookies.get.mockReturnValue(true)
       const wrapper = mount(
         <Router>
           <Navbar {...props} />
         </Router>
       )
-      expect(wrapper.find('MenuItem').length).toEqual(7)
+      const logOutLink = wrapper.find('a').filterWhere(item => {
+        return item.text() === 'Log out'
+      })
+      logOutLink.simulate('click')
+      expect(props.cookies.remove).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously, users could only log in, but not log out
#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne-FE/issues  -->

fixes #140 

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->
![screenshot at 2019-03-07 15 01 55](https://user-images.githubusercontent.com/26943915/53978455-001df900-40ea-11e9-934a-82d5c8331525.png)

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne-FE/blob/develop/CONTRIBUTING.md#git-and-github-->
updated tests to check the presence of a log out link which when clicked removes the cookies