### PR TITLE
204 add slack channel name on create new project form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ cypress/videos
 cypress/screenshots
 .env
 .vscode/
+.idea
 yarn-error.log
 .tool-versions

--- a/cypress/fixtures/newlyCreatedProject.json
+++ b/cypress/fixtures/newlyCreatedProject.json
@@ -1,8 +1,9 @@
 {
-    "project": {
+  "project": {
     "id": 3,
     "title": "NewProject",
     "description": "A new project",
+    "slack": "new slack",
     "status": "Active",
     "created_at": "2018-10-18T20:54:13.525Z",
     "updated_at": "2018-10-18T20:54:13.525Z",

--- a/cypress/integration/common/web_steps.js
+++ b/cypress/integration/common/web_steps.js
@@ -296,6 +296,8 @@ Then('I should be able to create a new project', () => {
       .type('NewProject')
       .get('textarea[name=description]')
       .type('A new project')
+      .get('input[name=slack]')
+      .type('A new slack')
       .get('button[type=submit]')
       .click()
       .url().should('include', '/projects/newproject')

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "AgileVentures",
   "license": "MIT",
   "scripts": {
+    "testWatch":"TERM=dumb jest  --watch",
     "start": "webpack-dev-server --mode development --open",
     "start-test-server": "webpack-dev-server --mode development --port 8082",
     "build": "webpack --mode production",

--- a/src/actions/createProjectAction.js
+++ b/src/actions/createProjectAction.js
@@ -9,6 +9,7 @@ export let createProject = props => dispatch => {
     title,
     description,
     status,
+    slack,
     cookies
   } = props
   return axios({
@@ -18,7 +19,8 @@ export let createProject = props => dispatch => {
       project: {
         title,
         description,
-        status
+        status,
+        slack
       }
     },
     headers: {

--- a/src/components/ProjectForm.js
+++ b/src/components/ProjectForm.js
@@ -1,37 +1,39 @@
 import React from 'react'
 import { Button, Form } from 'semantic-ui-react'
-import { InputField, SelectField, TextAreaField } from 'react-semantic-redux-form'
-import { Field, reduxForm } from 'redux-form'
 
-export const ProjectForm = props => {
-  const options = [
-    { key: 'select', value: '', text: 'Choose One' },
-    { key: 'one', value: 'Active', text: 'Active' },
-    { key: 'two', value: 'Inactive', text: 'Inactive' }
-  ]
-
+const ProjectForm = props => {
   return (
     <Form onSubmit={props.handleSubmit}>
-      <Field name='title' component={InputField}
+      <Form.Input
         label='Title'
-        placeholder='Title' required />
-      <Field name='description' component={TextAreaField}
-        label='Description'
-        placeholder='Description' required />
-      <Field name='status'
-        component={SelectField}
-        label='Status'
-        options={options}
-        placeholder='Status'
+        placeholder='Project title'
+        name='title'
+        value={props.title}
+        onChange={props.onChange}
+        required
       />
-      <Form.Field control={Button} primary
-        type='submit' >
-        Create Project
-      </Form.Field>
+      <Form.TextArea
+        label='Description'
+        placeholder='Project description'
+        name='description'
+        value={props.description}
+        onChange={props.onChange}
+        required
+      />
+      <Form.Input
+        label='Slack channel name'
+        placeholder='Project slack channel name'
+        name='slack'
+        value={props.slack}
+        onChange={props.onChange}
+      />
+      <select name='status' id='status' onChange={props.onChange} required>
+        <option value='Active'>Active</option>
+        <option value='Inactive'>Inactive</option>
+      </select>
+      <Button style={{ margin: '20px auto' }} type='submit'> Create Project </Button>{' '}
     </Form>
   )
 }
 
-export default reduxForm({
-  form: 'Project'
-})(ProjectForm)
+export default ProjectForm

--- a/src/containers/CreateProjectPage.js
+++ b/src/containers/CreateProjectPage.js
@@ -16,13 +16,14 @@ export class CreateProjectPage extends Component {
   }
 
   handleSubmit = event => {
-    const { title, description, status } = this.state
+    const { title, description, status, slack } = this.state
     const { createProject, history, cookies } = this.props
     event.preventDefault()
     createProject({
       title,
       description,
       status,
+      slack,
       cookies,
       history
     })

--- a/src/containers/CreateProjectPage.js
+++ b/src/containers/CreateProjectPage.js
@@ -4,9 +4,21 @@ import { connect } from 'react-redux'
 import ProjectForm from '../components/ProjectForm'
 import { createProject } from '../actions/createProjectAction'
 export class CreateProjectPage extends Component {
-  handleSubmit = values => {
-    const { title, description, status } = values
+  state = {
+    title: '',
+    description: '',
+    slack: '',
+    status: 'Active'
+  }
+
+  handleChange = (e, { name, value }) => {
+    this.setState({ [name]: value })
+  }
+
+  handleSubmit = event => {
+    const { title, description, status } = this.state
     const { createProject, history, cookies } = this.props
+    event.preventDefault()
     createProject({
       title,
       description,
@@ -17,24 +29,32 @@ export class CreateProjectPage extends Component {
   }
 
   render () {
+    let { title, description, status, slack } = this.state
     return (
-      <Container >
-        <Header as='h1'
-          textAlign='center' > Creating a new Project </Header>
+      <Container>
+        <Header as='h1' textAlign='center'>
+          {' '}
+          Creating a new Project{' '}
+        </Header>
         <ProjectForm
-          onSubmit={this.handleSubmit}
+          handleSubmit={this.handleSubmit}
+          onChange={this.handleChange}
+          title={title}
+          description={description}
+          slack={slack}
+          status={status}
           cookies={this.props.cookies}
         />
-      </Container >
+      </Container>
     )
   }
 }
-
 const mapStateToProps = (store, ownProps) => ({
   cookies: ownProps.cookies
 })
 export default connect(
-  mapStateToProps, {
+  mapStateToProps,
+  {
     createProject
   }
 )(CreateProjectPage)

--- a/src/tests/actions/createProjectAction.test.js
+++ b/src/tests/actions/createProjectAction.test.js
@@ -5,7 +5,7 @@ import configureMockStore from 'redux-mock-store'
 import { CREATE_PROJECT } from '../../types'
 import newProject from '../../../cypress/fixtures/newlyCreatedProject'
 
-describe('createProject', () => {
+describe.only('createProject', () => {
   const middlewares = [thunk]
   const mockStore = configureMockStore(middlewares)
   let store
@@ -13,7 +13,8 @@ describe('createProject', () => {
   const props = {
     title: 'PairProgramming Rocks',
     description: 'Project all about pair programming',
-    status: 'active',
+    slack: 'new slack',
+    status: 'Active',
     cookies: { get: jest.fn() },
     history: { push: jest.fn() }
   }
@@ -25,17 +26,21 @@ describe('createProject', () => {
     moxios.uninstall()
   })
 
-  it('posts project info to Rails backend and returns without error', async () => {
+  it.only('posts project info to Rails backend and returns without error', async () => {
     const expectedActions = [{ type: CREATE_PROJECT, payload: newProject }]
-    expect.assertions(1)
     moxios.wait(() => {
       const request = moxios.requests.mostRecent()
+
+      Object.keys(props).forEach(key => {
+        if (newProject.project[`${key}`]) {
+          newProject.project[`${key}`] = props[`${key}`]
+        }
+      })
       request.resolve({ data: newProject })
     })
-
-    return store.dispatch(createProject(props)).then(() => {
-      expect(store.getActions()).toEqual(expectedActions)
-    })
+    await store.dispatch(createProject(props))
+    const actionReturn = store.getActions()
+    expect(actionReturn).toEqual(expectedActions)
   })
 
   it('dispatches an error if it is returned', () => {

--- a/src/tests/components/ProjectForm.test.js
+++ b/src/tests/components/ProjectForm.test.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ProjectForm } from '../../components/ProjectForm'
+import ProjectForm from '../../components/ProjectForm'
 
-describe('ProjectForm', () => {
+describe.only('ProjectForm', () => {
   let wrapper
   let props = {
     handleSubmit: jest.fn()
   }
 
   beforeEach(() => {
+    console.log(ProjectForm)
     wrapper = shallow(<ProjectForm {...props} />)
   })
 

--- a/src/tests/containers/CreateProjectPage.test.js
+++ b/src/tests/containers/CreateProjectPage.test.js
@@ -33,9 +33,17 @@ describe('CreateProjectPage', () => {
     })
     const submitForm = wrapper.find('Form')
     titleInput.simulate('change', { target: { value: 'Predicted Title' } })
-    descriptionInput.simulate('change', { target: { value: 'Happy description here' } })
+    descriptionInput.simulate('change', {
+      target: { value: 'Happy description here' }
+    })
     submitForm.simulate('submit')
 
     expect(props.createProject).toHaveBeenCalledTimes(1)
+  })
+  it('include slack channel input filed', () => {
+    const slackInput = wrapper.find('input').filterWhere(item => {
+      return item.prop('name') === 'slack'
+    })
+    expect.any(slackInput)
   })
 })


### PR DESCRIPTION
Issue addressed
Add form field to add slack channel name on Create New Project form issue 204

fixes #
Expected Behavior
Add Form input field to add slack_channel_name
Add a label next to the Input field displaying slack_channel_name
Current Behavior
There is no form input field for slack channel name.

Possible Solution
Add Semantic UI react Form.Input to add Input to add field to the form



test:
the original unit test for action has problem use the newproject data to compare with newproject and always show success.