### PR TITLE
removing componentWillReceiveProps

### DIFF
--- a/src/components/EventSummary.js
+++ b/src/components/EventSummary.js
@@ -7,7 +7,7 @@ import moment from 'moment-timezone'
 
 const EventSummary = props => {
   let { event } = props
-  if (event) {
+  if (event && Object.entries(event).length > 0) {
     let startTime = moment(event.start_datetime)
     let endTime = startTime.clone().add(Number(event.duration), 'minutes')
     let timeRange = `${startTime.format('HH:mm')} - ${endTime.format('HH:mm')}  ${moment.tz.guess()}`

--- a/src/components/ProjectSummary.js
+++ b/src/components/ProjectSummary.js
@@ -66,7 +66,7 @@ const ProjectSummary = props => {
                                   <a
                                     href={`https://agileventures.slack.com/app_redirect?channel=${
                                       project.slack_channel_name
-                                      }`}
+                                    }`}
                                   >
                                     {project.title}
                                   </a>

--- a/src/components/ProjectSummary.js
+++ b/src/components/ProjectSummary.js
@@ -7,7 +7,7 @@ import '../assets/ProjectSummary.css'
 
 const ProjectSummary = props => {
   let { project } = props
-  if (project) {
+  if (project && Object.keys(project).length > 0) {
     return (
       <Grid columns={2} stackable>
         <Grid.Column width={12}>
@@ -66,7 +66,7 @@ const ProjectSummary = props => {
                                   <a
                                     href={`https://agileventures.slack.com/app_redirect?channel=${
                                       project.slack_channel_name
-                                    }`}
+                                      }`}
                                   >
                                     {project.title}
                                   </a>

--- a/src/components/UserSummary.js
+++ b/src/components/UserSummary.js
@@ -7,7 +7,7 @@ import '../assets/UserSummary.css'
 
 const UserSummary = props => {
   let { user } = props
-  if (user) {
+  if (user && Object.keys(user).length > 0) {
     const latestUserContributionList = user.contributions
       .sort((a, b) => b - a)
       .slice(0, 6)

--- a/src/containers/CreateEventPage.js
+++ b/src/containers/CreateEventPage.js
@@ -10,7 +10,6 @@ import momentTZ from 'moment-timezone'
 
 export class CreateEventPage extends Component {
   state = {
-    projects: null,
     startDate: new Date(),
     endDate: new Date(),
     name: '',
@@ -35,12 +34,6 @@ export class CreateEventPage extends Component {
       this.props.fetchActiveProjects()
     } else {
       this.setState({ projects: this.props.projects })
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    if (this.props.projects !== nextProps.projects) {
-      this.setState({ projects: nextProps.projects })
     }
   }
 
@@ -125,6 +118,7 @@ export class CreateEventPage extends Component {
           name={name}
           category={category}
           eventFor={eventFor}
+          projects={this.props.projects}
           projectId={projectId}
           description={description}
           startDate={startDate}

--- a/src/containers/EventInfo.js
+++ b/src/containers/EventInfo.js
@@ -6,8 +6,6 @@ import { Container } from 'semantic-ui-react'
 import EventSummary from '../components/EventSummary'
 
 export class EventInfo extends Component {
-  state = { event: null };
-
   componentDidMount () {
     const eventSlug = this.props.match.params.slug
     this.props.setLastLocation(this.props.location.pathname)
@@ -18,17 +16,10 @@ export class EventInfo extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.event !== nextProps.event) {
-      this.setState({ event: nextProps.event })
-    }
-  }
-
   render () {
-    let { event } = this.state
     return (
       <Container className='event-info-container'>
-        <EventSummary event={event} />
+        <EventSummary event={this.props.event} />
       </Container>
     )
   }

--- a/src/containers/ProjectInfo.js
+++ b/src/containers/ProjectInfo.js
@@ -9,9 +9,7 @@ export class ProjectInfo extends Component {
   componentDidMount () {
     const projectSlug = this.props.match.params.slug
     this.props.setLastLocation(this.props.location.pathname)
-    if (this.props.project.slug === this.props.match.params.slug) {
-      this.setState({ project: this.props.project })
-    } else {
+    if (this.props.project.slug !== this.props.match.params.slug) {
       this.props.fetchProjectInfo(projectSlug)
     }
   }

--- a/src/containers/ProjectInfo.js
+++ b/src/containers/ProjectInfo.js
@@ -6,7 +6,7 @@ import { Container } from 'semantic-ui-react'
 import ProjectSummary from '../components/ProjectSummary'
 
 export class ProjectInfo extends Component {
-  componentDidMount() {
+  componentDidMount () {
     const projectSlug = this.props.match.params.slug
     this.props.setLastLocation(this.props.location.pathname)
     if (this.props.project.slug === this.props.match.params.slug) {
@@ -16,8 +16,7 @@ export class ProjectInfo extends Component {
     }
   }
 
-  render() {
-    let { project } = this.state
+  render () {
     return (
       <Container className='project-info-container'>
         <ProjectSummary project={this.props.project} />

--- a/src/containers/ProjectInfo.js
+++ b/src/containers/ProjectInfo.js
@@ -6,8 +6,6 @@ import { Container } from 'semantic-ui-react'
 import ProjectSummary from '../components/ProjectSummary'
 
 export class ProjectInfo extends Component {
-  state = { project: null };
-
   componentDidMount () {
     const projectSlug = this.props.match.params.slug
     this.props.setLastLocation(this.props.location.pathname)
@@ -18,19 +16,16 @@ export class ProjectInfo extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.project !== nextProps.project) {
-      this.setState({ project: nextProps.project })
-    }
-  }
-
   render () {
-    let { project } = this.state
-    return (
-      <Container className='project-info-container'>
-        <ProjectSummary project={project} />
-      </Container>
-    )
+    if (Object.entries(this.props.project).length > 0) {
+      return (
+        <Container className='project-info-container'>
+          <ProjectSummary project={this.props.project} />
+        </Container>
+      )
+    } else {
+      return null
+    }
   }
 }
 

--- a/src/containers/ProjectInfo.js
+++ b/src/containers/ProjectInfo.js
@@ -6,7 +6,7 @@ import { Container } from 'semantic-ui-react'
 import ProjectSummary from '../components/ProjectSummary'
 
 export class ProjectInfo extends Component {
-  componentDidMount () {
+  componentDidMount() {
     const projectSlug = this.props.match.params.slug
     this.props.setLastLocation(this.props.location.pathname)
     if (this.props.project.slug === this.props.match.params.slug) {
@@ -16,16 +16,13 @@ export class ProjectInfo extends Component {
     }
   }
 
-  render () {
-    if (Object.entries(this.props.project).length > 0) {
-      return (
-        <Container className='project-info-container'>
-          <ProjectSummary project={this.props.project} />
-        </Container>
-      )
-    } else {
-      return null
-    }
+  render() {
+    let { project } = this.state
+    return (
+      <Container className='project-info-container'>
+        <ProjectSummary project={this.props.project} />
+      </Container>
+    )
   }
 }
 

--- a/src/containers/ProjectsList.js
+++ b/src/containers/ProjectsList.js
@@ -41,12 +41,9 @@ export class ProjectsList extends Component {
     this.props.setLastLocation(this.props.location.pathname)
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (
-      this.props.projects.length !== nextProps.projects.length &&
-      !nextProps.projects[0].error
-    ) {
-      this.paginateProjects(nextProps.projects)
+  componentDidUpdate () {
+    if (this.props.projects.length > 0 && this.state.projectsList.length === 0) {
+      this.paginateProjects(this.props.projects)
     }
   }
 
@@ -180,7 +177,7 @@ export class ProjectsList extends Component {
                   <Grid.Row>
                     <Grid.Column floated='left' width={9}>
                       <Header className='projects-list-header' as='h1'>
-                      List of Projects
+                        List of Projects
                       </Header>
                     </Grid.Column>
                     <Grid.Column floated='right' width={3}>
@@ -200,14 +197,14 @@ export class ProjectsList extends Component {
                 </Grid>
                 <div>
                   <p>
-                  To get involved in any of the projects, join one of the
+                    To get involved in any of the projects, join one of the
                     <Link to={`/events`}> scrums </Link>and reach out to us, or
                   send us an email at
                     <a href='mailto:info@agileventures.org'>
                       {' '}
-                    info@agileventures.org
+                      info@agileventures.org
                     </a>
-                  .
+                    .
                   </p>
                 </div>
                 <div className='search-dropdown'>

--- a/src/containers/ProjectsList.js
+++ b/src/containers/ProjectsList.js
@@ -42,7 +42,7 @@ export class ProjectsList extends Component {
   }
 
   componentDidUpdate () {
-    if (this.props.projects.length > 0 && this.state.projectsList.length === 0) {
+    if (this.props.projects.length > 0 && this.state.languages.length === 0) {
       this.paginateProjects(this.props.projects)
     }
   }
@@ -61,9 +61,7 @@ export class ProjectsList extends Component {
         lastIndex += 12
       }
     }
-
     this.addLanguagesToProjectsObject(projects, paginatedProjects)
-
     this.setState({
       projects: paginatedProjects,
       pageCount,

--- a/src/containers/UserProfile.js
+++ b/src/containers/UserProfile.js
@@ -7,8 +7,6 @@ import { setLastLocation } from '../actions/setLastLocationAction'
 import '../assets/UserProfile.css'
 
 export class UserProfile extends Component {
-  state = { user: null }
-
   componentDidMount () {
     const userId = Number(this.props.match.params.id)
     this.props.setLastLocation(this.props.location.pathname)
@@ -19,17 +17,10 @@ export class UserProfile extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.user !== nextProps.user) {
-      this.setState({ user: nextProps.user })
-    }
-  }
-
   render () {
-    let { user } = this.state
     return (
       <Container className='user-profile-container'>
-        <UserSummary user={user} />
+        <UserSummary user={this.props.user} />
       </Container>
     )
   }

--- a/src/containers/UserProfile.js
+++ b/src/containers/UserProfile.js
@@ -10,9 +10,7 @@ export class UserProfile extends Component {
   componentDidMount () {
     const userId = Number(this.props.match.params.id)
     this.props.setLastLocation(this.props.location.pathname)
-    if (this.props.user.id === this.props.match.params.id) {
-      this.setState({ user: this.props.user })
-    } else {
+    if (this.props.user.id !== this.props.match.params.id) {
       this.props.fetchUserInfo(userId)
     }
   }

--- a/src/containers/UsersList.js
+++ b/src/containers/UsersList.js
@@ -30,7 +30,7 @@ export class UsersList extends Component {
   }
 
   componentDidUpdate () {
-    if (this.props.users.length > 0 && this.state.usersList.length === 0) {
+    if (this.props.users.length > 0 && this.state.usersList && this.state.usersList.length === 0) {
       this.normalizeUsers(this.props.users)
     }
   }

--- a/src/containers/UsersList.js
+++ b/src/containers/UsersList.js
@@ -15,7 +15,7 @@ export class UsersList extends Component {
       lastPage: true,
       pageCount: null,
       usersList: [],
-      users: {},
+      users: [],
       selectedPage: 1
     }
   }
@@ -29,9 +29,9 @@ export class UsersList extends Component {
     this.props.setLastLocation(this.props.location.pathname)
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.users.length !== nextProps.users.length) {
-      this.normalizeUsers(nextProps.users)
+  componentDidUpdate () {
+    if (this.props.users.length > 0 && this.state.usersList.length === 0) {
+      this.normalizeUsers(this.props.users)
     }
   }
 

--- a/src/fixtures/userInfo.js
+++ b/src/fixtures/userInfo.js
@@ -88,7 +88,7 @@ export let user = {
   deleted_at: null,
   event_participation_count: 0,
   can_see_dashboard: false,
-  skill_list: [],
+  skill_list: ['Java', 'C++'],
   title_list: ['Mentor'],
   karmaTotal: 108,
   gravatarUrl:

--- a/src/tests/components/UserSummary.test.js
+++ b/src/tests/components/UserSummary.test.js
@@ -21,6 +21,53 @@ describe('UserSummary', () => {
     expect(userProfileName.text()).toEqual(user.slug)
   })
 
+  it('renders CustomRingLoader if user props is an empty object', () => {
+    const props = {
+      user: {}
+    }
+    wrapper = mount(<UserSummary {...props} />)
+    expect(wrapper.find('CustomRingLoader')).toHaveLength(1)
+  })
+
+  it('shows user bio if Bio tab is clicked', () => {
+    const menuTab = wrapper.find('MenuItem[name="Bio"]')
+    menuTab.simulate('click')
+    wrapper.update()
+    expect(wrapper.contains(user.bio)).toEqual(true)
+  })
+
+  it('shows user projects if Projects tab is clicked', () => {
+    const menuTab = wrapper.find('MenuItem[name="Projects"]')
+    menuTab.simulate('click')
+    wrapper.update()
+    user.projects.forEach(project => {
+      expect(wrapper.contains(project.title)).toEqual(true)
+    })
+  })
+
+  it('shows user skills if Skills tab is clicked', () => {
+    const menuTab = wrapper.find('MenuItem[name="Skills"]')
+    menuTab.simulate('click')
+    wrapper.update()
+    user.skill_list.forEach(skill => {
+      expect(wrapper.contains(skill)).toEqual(true)
+    })
+  })
+
+  it('shows user contributions if Activity tab is clicked', () => {
+    const menuTab = wrapper.find('MenuItem[name="Activity"]')
+    menuTab.simulate('click')
+    wrapper.update()
+    user.projects.map(project => {
+      return user.contributions.map(usersProject => {
+        if (usersProject.project_id === project.id) {
+          expect(wrapper.contains(usersProject.commit_count.toString())).toEqual(true)
+          expect(wrapper.contains(project.title)).toEqual(true)
+        }
+      })
+    })
+  })
+
   it("displays a user's github username", () => {
     user.github_profile_url = 'https://github.com/mattwr18'
     wrapper = mount(<UserSummary user={user} />)

--- a/src/tests/containers/CreateEventPage.test.js
+++ b/src/tests/containers/CreateEventPage.test.js
@@ -29,6 +29,10 @@ describe('CreateEventPage', () => {
     expect(props.history.push).toHaveBeenCalledWith({ pathname: '/login' })
   })
 
+  it('calls fetchActiveProjects when props.projects is empty', () => {
+    expect(props.fetchActiveProjects).toBeCalled()
+  })
+
   it('calls createEvent when the form in submitted', () => {
     const context = {}
     wrapper = mount(

--- a/src/tests/containers/CreateEventPage.test.js
+++ b/src/tests/containers/CreateEventPage.test.js
@@ -29,20 +29,6 @@ describe('CreateEventPage', () => {
     expect(props.history.push).toHaveBeenCalledWith({ pathname: '/login' })
   })
 
-  it('sets state with projects if received from props', () => {
-    const expected = [{ id: 3, name: 'Project1' }]
-    props.projects = expected
-    wrapper = shallow(<CreateEventPage {...props} />)
-    expect(wrapper.state().projects).toEqual(expected)
-  })
-
-  it('sets state when props are updated', () => {
-    const expected = [{ id: 3, name: 'Project1' }]
-    wrapper.setProps({ projects: expected })
-    wrapper = shallow(<CreateEventPage {...props} />)
-    expect(wrapper.state().projects).toEqual(expected)
-  })
-
   it('calls createEvent when the form in submitted', () => {
     const context = {}
     wrapper = mount(

--- a/src/tests/containers/EventInfo.test.js
+++ b/src/tests/containers/EventInfo.test.js
@@ -11,7 +11,7 @@ describe('Event Info', () => {
       slug: 'weekendcollaboration'
     },
     fetchEventInfo: jest.fn(),
-    setLastLocation: () => {},
+    setLastLocation: () => { },
     location: 'events/madwriter'
   }
   beforeEach(() => {
@@ -20,11 +20,6 @@ describe('Event Info', () => {
 
   it('renders event summary page', () => {
     expect(wrapper.find('EventSummary')).toBeTruthy()
-  })
-
-  it('sets state if the event props are updated', () => {
-    wrapper.setProps({ event })
-    expect(wrapper.state().event).toEqual(event)
   })
 
   it('calls fetchEventInfo if the event slug is different from the event slug in the url', () => {

--- a/src/tests/containers/ProjectInfo.test.js
+++ b/src/tests/containers/ProjectInfo.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { ProjectInfo } from '../../containers/ProjectInfo'
-import project from '../../fixtures/projectInfo'
 
 describe('ProjectInfo', () => {
   let wrapper
@@ -11,7 +10,7 @@ describe('ProjectInfo', () => {
       slug: 'rundfunk-mitbestimmen'
     },
     fetchProjectInfo: jest.fn(),
-    setLastLocation: () => {},
+    setLastLocation: () => { },
     location: { pathname: '/projects/websiteone' }
   }
   beforeEach(() => {
@@ -24,15 +23,5 @@ describe('ProjectInfo', () => {
 
   it('calls fetchProjectInfo if the project slug is different from the project slug in the url', () => {
     expect(props.fetchProjectInfo).toHaveBeenLastCalledWith(props.match.params.slug)
-  })
-
-  it('sets state if the project props are updated', () => {
-    wrapper.setProps({ project })
-    expect(wrapper.state().project).toEqual(project)
-  })
-
-  it('sets state if the project slug is the same as in the url', () => {
-    wrapper = shallow(<ProjectInfo {...props} project={project} />)
-    expect(wrapper.state().project).toEqual(project)
   })
 })

--- a/src/tests/containers/ProjectsList.test.js
+++ b/src/tests/containers/ProjectsList.test.js
@@ -19,7 +19,7 @@ describe('ProjectsList', () => {
       }),
     filteredProjectsList: null,
     error: false,
-    setLastLocation: () => {},
+    setLastLocation: () => { },
     location: { pathname: '/projects' }
   }
   wrapper = mount(
@@ -52,8 +52,8 @@ describe('ProjectsList', () => {
     const wrapper = shallow(
       <ProjectsList
         projects={paginatedProjectsFixture}
-        fetchProjects={() => {}}
-        setLastLocation={() => {}}
+        fetchProjects={() => { }}
+        setLastLocation={() => { }}
         location={{ pathname: '/projects' }}
       />
     )
@@ -95,8 +95,8 @@ describe('ProjectsList', () => {
       <StaticRouter context={context}>
         <ProjectsList
           projects={{ 1: [] }}
-          fetchProjects={() => {}}
-          setLastLocation={() => {}}
+          fetchProjects={() => { }}
+          setLastLocation={() => { }}
           location={{ pathname: '/projects' }}
         />
       </StaticRouter>
@@ -104,27 +104,12 @@ describe('ProjectsList', () => {
     expect(wrapper.find('Project')).toHaveLength(0)
   })
 
-  it('should test componentWillReceiveProps', () => {
+  it('should call paginateProjects', () => {
     const wrapper = shallow(
       <ProjectsList
         projects={[]}
-        fetchProjects={() => {}}
-        setLastLocation={() => {}}
-        location={{ pathname: '/projects' }}
-      />
-    )
-    wrapper.setProps({ projects: [{ id: 1, languages: [] }] })
-    expect(wrapper.instance().state.projects).toEqual({
-      '1': [{ id: 1, languages: [] }]
-    })
-  })
-
-  it('should call normalizeFilteredProjects', () => {
-    const wrapper = shallow(
-      <ProjectsList
-        projects={[]}
-        fetchProjects={() => {}}
-        setLastLocation={() => {}}
+        fetchProjects={() => { }}
+        setLastLocation={() => { }}
         location={{ pathname: '/projects' }}
       />
     )
@@ -151,8 +136,8 @@ describe('ProjectsList', () => {
       <ProjectsList
         projects={[]}
         error={[]}
-        fetchProjects={() => {}}
-        setLastLocation={() => {}}
+        fetchProjects={() => { }}
+        setLastLocation={() => { }}
         location={{ pathname: '/projects' }}
       />
     )

--- a/src/tests/containers/UserList.test.js
+++ b/src/tests/containers/UserList.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { UsersList } from '../../containers/UsersList'
 import usersFixture from '../../fixtures/users'
 import { StaticRouter } from 'react-router'
@@ -18,7 +18,7 @@ describe('UsersList', () => {
             }, 300)
           })
         }
-        setLastLocation={() => {}}
+        setLastLocation={() => { }}
         location={{ pathname: '/users' }}
       />
     </StaticRouter>
@@ -108,21 +108,9 @@ describe('UsersList', () => {
   it("shouldn't render a Project component without users", () => {
     const wrapper = mount(
       <StaticRouter context={context}>
-        <UsersList users={[]} fetchUsers={() => {}} setLastLocation={() => {}} location={{ pathname: '/users' }} />
+        <UsersList users={[]} fetchUsers={() => { }} setLastLocation={() => { }} location={{ pathname: '/users' }} />
       </StaticRouter>
     )
     expect(wrapper.find('User')).toHaveLength(0)
-  })
-
-  it('should test componentWillReceiveProps', () => {
-    const wrapper = shallow(<UsersList users={[]} fetchUsers={() => {}} setLastLocation={() => {}} location={{ pathname: '/users' }} />)
-    wrapper.setProps({ users: ['something'] })
-    expect(wrapper.instance().state.users).toEqual({ '1': ['something'] })
-  })
-
-  it('should test componentWillReceiveProps', () => {
-    const wrapper = shallow(<UsersList users={usersFixture} fetchUsers={() => {}} setLastLocation={() => {}} location={{ pathname: '/users' }} />)
-    wrapper.setProps(usersFixture)
-    expect(wrapper.instance().state.users[1][0]).toEqual(usersFixture[0])
   })
 })

--- a/src/tests/containers/UserProfile.test.js
+++ b/src/tests/containers/UserProfile.test.js
@@ -8,36 +8,21 @@ describe('UserProfile', () => {
   const props = {
     match: { params: { id: 1 } },
     userId: user.id,
-    user: { id: 2 },
+    user,
     fetchUserInfo: jest.fn(),
-    setLastLocation: () => {},
+    setLastLocation: () => { },
     location: { pathname: '/users/2' }
   }
-  beforeEach(() => {
-    wrapper = mount(<UserProfile {...props} />)
-  })
 
   it('renders UserSummary', () => {
+    wrapper = mount(<UserProfile {...props} />)
+    wrapper.update()
     expect(wrapper.find('UserSummary')).toBeTruthy()
   })
 
   it('calls fetchUserInfo if their user id is different from the user id in the url', () => {
+    props.user.id = 2
+    wrapper = mount(<UserProfile {...props} />)
     expect(props.fetchUserInfo).toHaveBeenCalledWith(props.match.params.id)
-  })
-
-  it('sets state if the user props are updated', () => {
-    wrapper.setProps({ user })
-    expect(wrapper.state().user).toEqual(user)
-  })
-
-  it('sets state if the user id is the same as in the url', () => {
-    wrapper = mount(
-      <UserProfile
-        {...props}
-        user={user}
-      />
-    )
-    wrapper.update()
-    expect(wrapper.state().user).toEqual(user)
   })
 })


### PR DESCRIPTION
I think that componentWillReceiveProps can be removed from all the containers that include it. I don't think that it is necessary to mirror state in the store with local state in the containers and then make a check for updated props in componentWillReceiveProps. In some cases, where a check is needed, componentDidUpdate can be used instead. A lot of tests are broken here, I'm waiting to see if this approach seems reasonable.

src/components/EventSummary.js - check for empty event added
src/components/UserSummary.js - check for empty user added
src/containers/CreateEventPage.js - projects removed from state and this.props.projects added as prop to EventForm - event removed from state, using state from redux store instead
src/containers/EventInfo.js - event removed from state
src/containers/ProjectInfo.js  - project removed from state
src/containers/ProjectsList.js - componentDidUpdate used instead of componentWillReceiveProps
src/containers/UserProfile.js - user removed from state, using user from redux store instead
src/containers/UsersList.js - componentDidUpdate used instead of componentWillReceiveProps

fixes #165 