### PR TITLE
[WIP]stubs one request that is triggered when the 'save button' is clicked

### DIFF
--- a/cypress/integration/common/web_steps.js
+++ b/cypress/integration/common/web_steps.js
@@ -255,15 +255,20 @@ Then('I should be able to create a new event quickly', () => {
       response: newlyCreatedEventInfo,
       status: 200
     }).as('newlyCreatedEvent')
+    cy.route({
+      url: '/api/v1/events/newevent',
+      body: newlyCreatedEventInfo,
+      status: 200
+    })
     cy.get('input[name=name]')
       .type('NewEvent')
       .get('button')
       .contains('Save')
       .click()
       .url().should('include', '/events/newevent')
-    cy.window()
-      .its('store')
-      .invoke('dispatch', { type: 'GET_EVENT_INFO', payload: newlyCreatedEventInfo })
+    // cy.window()
+    //   .its('store')
+    //   .invoke('dispatch', { type: 'GET_EVENT_INFO', payload: newlyCreatedEventInfo })
   })
   cy.wait('@newlyCreatedEvent')
 })


### PR DESCRIPTION
Stubs one request that is triggered when the 'save button' is clicked during event creation.
This issue was discussed on [slack](https://agileventures.slack.com/archives/CAQGP1FST/p1558647516360700)

<!--- Provide a general summary of your changes in the Title above -->

#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne-FE/issues  -->
https://agileventures.slack.com/archives/CAQGP1FST/p1558647516360700

fixes #255 
#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne-FE/blob/develop/CONTRIBUTING.md#git-and-github-->
